### PR TITLE
fix session selection

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -24,7 +24,7 @@ module_information = ModuleInformation(
         'tv_atmos_token': '4N3n6Q1x95LL5K7p',
         'tv_atmos_secret': 'oKOXfJW371cX6xaZ0PyhgGNBdNLlBZd4AKKYougMjik=',
         'mobile_atmos_hires_token': 'km8T1xS355y7dd3H',
-        'mobile_default_token': 'WAU9gXp3tHhK4Nns',
+        'mobile_hires_token': '6BDSRdpK9hqEBTgU',
         'enable_mobile': True,
         'force_non_spatial': False,
         'prefer_ac4': False,
@@ -166,7 +166,7 @@ class ModuleInterface:
         elif session_type == SessionType.MOBILE_ATMOS.name:
             session = TidalMobileSession(self.settings['mobile_atmos_hires_token'])
         else:
-            session = TidalMobileSession(self.settings['mobile_default_token'])
+            session = TidalMobileSession(self.settings['mobile_hires_token'])
         return session
 
     def auth_session(self, session, session_type, login_session):

--- a/interface.py
+++ b/interface.py
@@ -471,19 +471,19 @@ class ModuleInterface:
                 format = 'ac3'
 
         session = {
-            'flac_hires': SessionType.MOBILE_ATMOS,
-            '360ra': SessionType.MOBILE_ATMOS,
+            'flac_hires': SessionType.MOBILE_DEFAULT,
+            '360ra': SessionType.MOBILE_DEFAULT,
             'ac4': SessionType.MOBILE_ATMOS,
             'ac3': SessionType.TV,
-            # MOBILE_DEFAULT is used whenever possible to avoid MPEG-DASH, which slows downloading
-            None: SessionType.MOBILE_DEFAULT,
+            # TV is used whenever possible to avoid MPEG-DASH, which slows downloading
+            None: SessionType.TV,
         }[format]
 
-        if not format and 'SONY_360RA' in media_tags:
-            # if 360RA is available, we don't use the mobile session here because that will get 360RA
+        if not format and 'DOLBY_ATMOS' in media_tags:
+            # if atmos is available, we don't use the TV session here because that will get atmos everytime
             # there are no tracks with both 360RA and atmos afaik,
             # so this shouldn't be an issue for now
-            session = SessionType.TV
+            session = SessionType.MOBILE_DEFAULT
 
         if session.name in self.available_sessions:
             self.session.default = session


### PR DESCRIPTION
this does two things:
- fix wrong formats being downloaded on atmos + hires tracks, this is why the mobile default session is changed ([example](https://tidal.com/browse/track/327818450))
- use the tv session more to get direct file downloads instead of MPEG-DASH

:3