### PR TITLE
rework spatial codec handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ loaded module. You'll find the configuration file here: `config/settings.json`
     "mobile_atmos_token": "dN2N95wCyEBTllu4",
     "mobile_default_token": "WAU9gXp3tHhK4Nns",
     "enable_mobile": true,
-    "force_non_spatial": false,
     "prefer_ac4": false,
     "fix_mqa": true
 }
@@ -154,7 +153,6 @@ loaded module. You'll find the configuration file here: `config/settings.json`
 | tv_secret         | Enter a valid TV client secret for the `tv_token`                                                                                                                                                                                                                                                                               |
 | mobile_*          | Enter a valid MOBILE client token for the desired session                                                                                                                                                                                                                                                                       |
 | enable_mobile     | Enables a second MOBILE session which needs a `username` and `password` (can be the same "TV" account) to archive Sony 360RA and Dolby AC-4 if available or allows `force_non_spatial` to work properly                                                                                                                         |
-| force_non_spatial | Forces a default Mobile session (`mobile_default_token` without support for Dolby Atmos at all, Sony 360RA will still be available) to get FLAC/AAC tracks                                                                                                                                                                      |
 | prefer_ac4        | If enabled and a mobile session is available (`enable_mobile` is set to `true`) this will ensure to get Dolby AC-4 on Dolby Atmos tracks                                                                                                                                                                                        |
 | fix_mqa           | If enabled it will download the MQA file before the actual track and analyze the FLAC file to extract the bitDepth and originalSampleRate. The tags `MQAENCODER`, `ENCODER` and `ORIGINALSAMPLERATE` are than added to the FLAC file in order to get properly detected by MQA enabled software such as Roon, UAPP or Audirvana. |
 


### PR DESCRIPTION
changes:
- session selection now uses spatial_codecs setting to determine whether to download spatial formats or not
if enabled, spatial formats are always downloaded if possible
if disabled, spatial formats are never downloaded if possible
- finally removed redundant force_non_spatial setting :3

fixes #54 